### PR TITLE
Update AUTHENTICATION panel title to "GoBang Game"

### DIFF
--- a/TP1/src/gui/enums/PanelType.java
+++ b/TP1/src/gui/enums/PanelType.java
@@ -1,7 +1,7 @@
 package gui.enums;
 
 public enum PanelType {
-    AUTHENTICATION("Othello Game",        400, 200),
+    AUTHENTICATION("GoBang Game",        400, 200),
     LOGIN         ("Login",               400, 250),
     REGISTRATION  ("Player Registration", 600, 300),
     LOBBY         ("Lobby",               600, 300),


### PR DESCRIPTION
Updated the name of the AUTHENTICATION panel in the `PanelType` enum from "Othello Game" to "GoBang Game." This change ensures the panel title accurately reflects the intended game.