### PR TITLE
✨ server tie victory detection

### DIFF
--- a/TP1/src/client/handler/ClientMessageHandler.java
+++ b/TP1/src/client/handler/ClientMessageHandler.java
@@ -90,6 +90,14 @@ public class ClientMessageHandler {
                 System.out.println("📥 Jogada recebida: " + who + " @ [" + row + "," + col + "]");
                 gui.onMove(row, col, who);
             }
+
+            case "gameEnd" -> {
+                String winner = XmlMessageReader.getTextValue(payload, "winner");
+                String reason = XmlMessageReader.getTextValue(payload, "reason");
+                String msg = XmlMessageReader.getTextValue(payload, "message");
+                System.out.println("🏁 Fim de jogo: " + reason + ". " + msg + (winner != null && !winner.isEmpty() ? " Vencedor: " + winner : ""));
+                gui.onGameEnd(winner, reason, msg);
+            }
         }
     }
 

--- a/TP1/src/common/GameClientListener.java
+++ b/TP1/src/common/GameClientListener.java
@@ -11,4 +11,5 @@ public interface GameClientListener {
     void onGameStart(String you, String opponent, boolean youStart);
     void onMove(int row, int col, String who);
     void onConnectionClosed();
+    void onGameEnd(String winner, String reason, String message);
 }

--- a/TP1/src/common/XmlMessageBuilder.java
+++ b/TP1/src/common/XmlMessageBuilder.java
@@ -90,4 +90,16 @@ public class XmlMessageBuilder {
                 "</move>";
         return wrapWithMessage(content);
     }
+
+    public static String buildGameEnd(String winner, String reason, String message) {
+        String content = "<gameEnd>";
+        if (winner != null && !winner.isEmpty()) {
+            content += "<winner>" + winner + "</winner>";
+        }
+        content += "<reason>" + reason + "</reason>";
+        content += "<message>" + message + "</message>";
+        content += "</gameEnd>";
+        return wrapWithMessage(content);
+    }
 }
+

--- a/TP1/src/common/xsd/gameEnd.xsd
+++ b/TP1/src/common/xsd/gameEnd.xsd
@@ -1,0 +1,12 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="gameEnd">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="winner" type="xs:string" minOccurs="0"/>
+                <xs:element name="reason" type="xs:string"/>
+                <xs:element name="message" type="xs:string"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>
+

--- a/TP1/src/common/xsd/gameProtocol.xsd
+++ b/TP1/src/common/xsd/gameProtocol.xsd
@@ -6,6 +6,7 @@
     <xs:include schemaLocation="updateProfileRequest.xsd"/>
     <xs:include schemaLocation="findMatch.xsd"/>
     <xs:include schemaLocation="cancelMatch.xsd"/>
+    <xs:include schemaLocation="gameEnd.xsd"/>
 
     <xs:element name="message">
         <xs:complexType>

--- a/TP1/src/gui/MainWindow.java
+++ b/TP1/src/gui/MainWindow.java
@@ -178,4 +178,23 @@ public class MainWindow extends JFrame implements GameClientListener {
         showError("Ligação encerrada", "O servidor fechou a ligação.");
         dispose();
     }
+
+    @Override
+    public void onGameEnd(String winner, String reason, String message) {
+        // Mostra um diálogo informativo ao utilizador com o resultado do jogo
+        String titulo = "Fim de Jogo";
+        StringBuilder msg = new StringBuilder();
+        if (reason != null) {
+            msg.append("Resultado: ").append(reason).append("\n");
+        }
+        if (winner != null && !winner.isEmpty()) {
+            msg.append("Vencedor: ").append(winner).append("\n");
+        }
+        if (message != null) {
+            msg.append(message);
+        }
+        JOptionPane.showMessageDialog(this, msg.toString(), titulo, JOptionPane.INFORMATION_MESSAGE);
+        // Volta ao lobby após o fim do jogo
+        changePanel(gui.enums.PanelType.LOBBY);
+    }
 }

--- a/TP1/src/server/handler/ActiveGamesManager.java
+++ b/TP1/src/server/handler/ActiveGamesManager.java
@@ -35,16 +35,26 @@ public class ActiveGamesManager {
         if (match != null) {
             boolean valid = match.applyMove(client, row, col);
             if (valid) {
-                // Mensagem de jogada válida para ambos os jogadores
                 String moveXml = common.XmlMessageBuilder.buildMoveRequest(client.getUsername(), row, col);
-                client.send(moveXml); // Confirmação ao jogador que jogou
+                client.send(moveXml);
                 ClientConnection opponent = match.getOpponent(client);
                 if (opponent != null) {
-                    opponent.send(moveXml); // Atualização ao adversário
+                    opponent.send(moveXml);
                 }
-                // Aqui podes adicionar lógica para verificar vitória/empate e enviar mensagem de fim de jogo
+                // Verificar vitória
+                if (match.isVictory(row, col)) {
+                    String winMsg = common.XmlMessageBuilder.buildGameEnd(client.getUsername(), "vitória", "Parabéns, ganhaste!");
+                    String loseMsg = common.XmlMessageBuilder.buildGameEnd(client.getUsername(), "derrota", "Perdeste o jogo.");
+                    client.send(winMsg);
+                    if (opponent != null) opponent.send(loseMsg);
+                    removeMatch(client);
+                } else if (match.isDraw()) {
+                    String drawMsg = common.XmlMessageBuilder.buildGameEnd("", "empate", "O jogo terminou empatado.");
+                    client.send(drawMsg);
+                    if (opponent != null) opponent.send(drawMsg);
+                    removeMatch(client);
+                }
             } else {
-                // Jogada inválida
                 client.send(common.XmlMessageBuilder.buildResponse(
                     "error",
                     "Jogada inválida (posição ocupada ou não é o seu turno).",

--- a/TP1/src/server/handler/GameMatch.java
+++ b/TP1/src/server/handler/GameMatch.java
@@ -50,6 +50,55 @@ public class GameMatch {
         return true;
     }
 
+    // Verifica se houve vitória a partir da última jogada
+    public boolean isVictory(int row, int col) {
+        CellState playerState = board[row][col];
+        if (playerState == CellState.EMPTY) return false;
+        // Verifica em todas as direções (horizontal, vertical, diagonais)
+        return checkDirection(row, col, 0, 1, playerState)   // Horizontal
+            || checkDirection(row, col, 1, 0, playerState)   // Vertical
+            || checkDirection(row, col, 1, 1, playerState)   // Diagonal descendente
+            || checkDirection(row, col, 1, -1, playerState); // Diagonal ascendente
+    }
+
+    // Verifica se há 5 em linha numa direção
+    private boolean checkDirection(int row, int col, int dRow, int dCol, CellState playerState) {
+        int count = 1;
+        // Para trás
+        int r = row - dRow, c = col - dCol;
+        while (isValid(r, c) && board[r][c] == playerState) {
+            count++;
+            r -= dRow;
+            c -= dCol;
+        }
+        // Para a frente
+        r = row + dRow;
+        c = col + dCol;
+        while (isValid(r, c) && board[r][c] == playerState) {
+            count++;
+            r += dRow;
+            c += dCol;
+        }
+        return count >= 5;
+    }
+
+    // Verifica se a posição está dentro do tabuleiro
+    private boolean isValid(int row, int col) {
+        return row >= 0 && row < 15 && col >= 0 && col < 15;
+    }
+
+    // Verifica se o tabuleiro está cheio (empate)
+    public boolean isDraw() {
+        for (int i = 0; i < 15; i++) {
+            for (int j = 0; j < 15; j++) {
+                if (board[i][j] == CellState.EMPTY) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
     public ClientConnection getOpponent(ClientConnection player) {
         return player.equals(player1) ? player2 : player1;
     }


### PR DESCRIPTION
This pull request introduces functionality to handle game-ending scenarios in the client-server architecture of the application. It includes changes to detect win/draw conditions, send appropriate game-end messages, and update the user interface accordingly. The most important changes are grouped into three themes: server-side game logic, client-side handling of game-end events, and XML schema updates.

### Server-side game logic:

* [`TP1/src/server/handler/GameMatch.java`](diffhunk://#diff-1a2615aa510d17c184ebb08371d0c972493f322ae00b7e5c42cd7f99b32170d2R53-R101): Added methods `isVictory`, `checkDirection`, `isValid`, and `isDraw` to detect win/draw conditions based on the current state of the game board. These methods implement logic for checking five-in-a-row victories and full-board draws.
* [`TP1/src/server/handler/ActiveGamesManager.java`](diffhunk://#diff-bfe09b745c0f42294cfdb02a605058b3e61043c50e0b4a62673452d8e74f35afL38-L47): Updated `processMove` to send game-end messages (`buildGameEnd`) to players upon detecting a victory or draw, and to remove the match after the game ends.

### Client-side handling of game-end events:

* [`TP1/src/client/handler/ClientMessageHandler.java`](diffhunk://#diff-1e1da8ee66e037ff74ee8125b5be48e4d729ec6bd8a65d01bb0e9810b7867785R93-R100): Added handling for the new `"gameEnd"` message type, which parses the winner, reason, and message from the payload and updates the GUI accordingly via `onGameEnd`.
* [`TP1/src/gui/MainWindow.java`](diffhunk://#diff-04acfc76aa48ec7c24ec87303f8e294f7b717ceaa4cfce77581211f592ef3ea7R181-R199): Implemented `onGameEnd` to display a dialog with game results and return the user to the lobby after the game ends.

### XML schema updates:

* [`TP1/src/common/XmlMessageBuilder.java`](diffhunk://#diff-28184c56d789db433550a7cdf238ea6b2fa94c725d66c320245d22d4cd296fe8R93-R105): Added `buildGameEnd` to construct XML messages for game-end events, including winner, reason, and message fields.
* [`TP1/src/common/xsd/gameEnd.xsd`](diffhunk://#diff-eade7081cbaf4f031d7d944b158781e780e641745f7bd647669e79b6471f00a4R1-R12): Created a new schema defining the structure of the `<gameEnd>` XML element, including optional `winner`, required `reason`, and required `message` fields.
* [`TP1/src/common/xsd/gameProtocol.xsd`](diffhunk://#diff-e231cb7a19297ac27e0c535e08d3d03588f44a5666e51d66dd674e2026b238acR9): Included the new `gameEnd.xsd` schema in the protocol definition to support game-end messages.