### PR TITLE
✨ Reset matchmaking UI after game ends

### DIFF
--- a/TP1/src/gui/Lobby.java
+++ b/TP1/src/gui/Lobby.java
@@ -82,4 +82,15 @@ public class Lobby extends JPanel {
         });
         add(logoutButton, gbc);
     }
+
+    public void resetMatchmakingUI() {
+        if (searchButton != null) searchButton.setVisible(true);
+        if (cancelButton != null) cancelButton.setVisible(false);
+        // Procura a label de pesquisa e limpa o texto
+        for (Component comp : getComponents()) {
+            if (comp instanceof JLabel label && label.getText().contains("Searching for a match")) {
+                label.setText("");
+            }
+        }
+    }
 }

--- a/TP1/src/gui/MainWindow.java
+++ b/TP1/src/gui/MainWindow.java
@@ -211,7 +211,15 @@ public class MainWindow extends JFrame implements GameClientListener {
             msg.append(message);
         }
         JOptionPane.showMessageDialog(this, msg.toString(), titulo, JOptionPane.INFORMATION_MESSAGE);
+
         // Volta ao lobby após o fim do jogo
-        changePanel(gui.enums.PanelType.LOBBY);
+        SwingUtilities.invokeLater(() -> {
+            for (Component comp : cardPanel.getComponents()) {
+                if (comp instanceof Lobby lobby) {
+                    lobby.resetMatchmakingUI();
+                }
+            }
+            changePanel(gui.enums.PanelType.LOBBY);
+        });
     }
 }

--- a/TP1/src/gui/MainWindow.java
+++ b/TP1/src/gui/MainWindow.java
@@ -8,6 +8,8 @@ import gui.enums.PanelType;
 
 import javax.swing.*;
 import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.Map;
 
 import static javax.swing.JOptionPane.*;
@@ -35,6 +37,15 @@ public class MainWindow extends JFrame implements GameClientListener {
 
         setContentPane(cardPanel);
         changePanel(PanelType.AUTHENTICATION);
+
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                if (client.getProfile() != null && client.getProfile().username() != null) {
+                    client.logout(client.getProfile().username());
+                }
+            }
+        });
     }
 
     public void changePanel(PanelType pt) {


### PR DESCRIPTION
This pull request introduces enhancements to the UI and user experience for the matchmaking and game flow in the `TP1` project. The changes include adding a method to reset the matchmaking UI, ensuring proper logout behavior when the application is closed, and improving the transition back to the lobby after a game ends.

### Matchmaking UI Enhancements:
* [`TP1/src/gui/Lobby.java`](diffhunk://#diff-d0129a4f875891e225fb61649d0bc0fbacce3578fdf36475f61580b5ec0f564fR85-R95): Added a `resetMatchmakingUI` method to reset the matchmaking interface. This method makes the search button visible, hides the cancel button, and clears the "Searching for a match" label text.

### Application Exit Behavior:
* [`TP1/src/gui/MainWindow.java`](diffhunk://#diff-04acfc76aa48ec7c24ec87303f8e294f7b717ceaa4cfce77581211f592ef3ea7R40-R48): Added a `WindowAdapter` to handle the window closing event. When the application is closed, it ensures the user is logged out if their profile exists.

### Game End Transition:
* [`TP1/src/gui/MainWindow.java`](diffhunk://#diff-04acfc76aa48ec7c24ec87303f8e294f7b717ceaa4cfce77581211f592ef3ea7R225-R234): Enhanced the `onGameEnd` method to reset the matchmaking UI in the lobby and transition back to the lobby panel using `SwingUtilities.invokeLater`.

### Code Refinements:
* [`TP1/src/gui/MainWindow.java`](diffhunk://#diff-04acfc76aa48ec7c24ec87303f8e294f7b717ceaa4cfce77581211f592ef3ea7R11-R12): Imported additional classes (`WindowAdapter` and `WindowEvent`) to support the window closing functionality.