### PR TITLE
✨ Add get ranking functionality and update XML response handling

### DIFF
--- a/TP1/src/common/XmlMessageBuilder.java
+++ b/TP1/src/common/XmlMessageBuilder.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public class XmlMessageBuilder {
 
-    
+
     private static String wrapWithMessage(String contentXml) {
         return "<message>" + contentXml + "</message>";
     }
@@ -48,7 +48,7 @@ public class XmlMessageBuilder {
         String content = "<response>" +
                 "<status>" + status + "</status>" +
                 "<message>" + message + "</message>" +
-                "<operation>" + operation + "</operation>"+
+                "<operation>" + operation + "</operation>" +
                 "</response>";
         return wrapWithMessage(content);
     }
@@ -115,20 +115,20 @@ public class XmlMessageBuilder {
     }
 
 
-   public static String buildResponse(String status, String message, String operation, String username, String photoBase64, int age, String nationality, int wins, int losses, long timePlayed, List<GameHistory> gamesHistory) {
+    public static String buildResponse(String status, String message, String operation, String username, String photoBase64, int age, String nationality, int wins, int losses, long timePlayed, List<GameHistory> gamesHistory) {
         String content = "<response>"
-            + "<status>" + status + "</status>"
-            + "<message>" + message + "</message>"
-            + "<operation>" + operation + "</operation>"
-            + "<username>" + username + "</username>"
-            + "<photo>" + (photoBase64 != null ? photoBase64 : "") + "</photo>"
-            + "<age>" + age + "</age>"
-            + "<nationality>" + nationality + "</nationality>"
-            + "<wins>" + wins + "</wins>"
-            + "<losses>" + losses + "</losses>"
-            + "<timePlayed>" + timePlayed + "</timePlayed>"
-            + buildGamesHistoryXml(gamesHistory)
-            + "</response>";
+                + "<status>" + status + "</status>"
+                + "<message>" + message + "</message>"
+                + "<operation>" + operation + "</operation>"
+                + "<username>" + username + "</username>"
+                + "<photo>" + (photoBase64 != null ? photoBase64 : "") + "</photo>"
+                + "<age>" + age + "</age>"
+                + "<nationality>" + nationality + "</nationality>"
+                + "<wins>" + wins + "</wins>"
+                + "<losses>" + losses + "</losses>"
+                + "<timePlayed>" + timePlayed + "</timePlayed>"
+                + buildGamesHistoryXml(gamesHistory)
+                + "</response>";
         return wrapWithMessage(content);
     }
 
@@ -137,5 +137,25 @@ public class XmlMessageBuilder {
                 "<username>" + username + "</username>" +
                 "</quitMatch>";
         return wrapWithMessage(content);
+    }
+
+    public static String buildRankingResponseArray(List<server.database.PlayerRecord> players) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<responseArray>");
+        for (server.database.PlayerRecord player : players) {
+            sb.append("<response>")
+                    .append("<status>success</status>")
+                    .append("<message>ranking</message>")
+                    .append("<operation>getRanking</operation>")
+                    .append("<username>").append(player.username()).append("</username>")
+                    .append("<photo>").append(player.photoBase64()).append("</photo>")
+                    .append("<nationality>").append(player.nationality()).append("</nationality>")
+                    .append("<wins>").append(player.wins()).append("</wins>")
+                    .append("<losses>").append(player.losses()).append("</losses>")
+                    .append("<timePlayed>").append(player.timePlayed()).append("</timePlayed>");
+            sb.append("</response>");
+        }
+        sb.append("</responseArray>");
+        return sb.toString();
     }
 }

--- a/TP1/src/common/xsd/gameProtocol.xsd
+++ b/TP1/src/common/xsd/gameProtocol.xsd
@@ -20,11 +20,13 @@
                 <xs:element ref="quitMatch"/>
                 <xs:element ref="player"/>
                 <xs:element ref="response"/>
+                <xs:element ref="responseArray"/>
                 <xs:element ref="updateProfileRequest"/>
                 <xs:element ref="getProfileRequest"/>
                 <xs:element ref="gameEnd"/>
                 <xs:element ref="findMatch"/>
                 <xs:element ref="cancelMatch"/>
+                <xs:element name="getRankingRequest" type="xs:string"/>
             </xs:choice>
         </xs:complexType>
     </xs:element>

--- a/TP1/src/common/xsd/response.xsd
+++ b/TP1/src/common/xsd/response.xsd
@@ -18,4 +18,12 @@
             </xs:sequence>
         </xs:complexType>
     </xs:element>
+
+    <xs:element name="responseArray">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="response" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
 </xs:schema>

--- a/TP1/src/server/database/UserDatabase.java
+++ b/TP1/src/server/database/UserDatabase.java
@@ -8,6 +8,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -113,5 +114,12 @@ public class UserDatabase implements Serializable {
     public synchronized void updatePlayer(PlayerRecord player) {
         users.put(player.username(), player);
         saveToFile();
+    }
+
+    /**
+     * Devolve uma lista de todos os jogadores registados.
+     */
+    public synchronized Collection<PlayerRecord> getAllPlayers() {
+        return users.values();
     }
 }

--- a/TP1/src/server/handler/ClientMessageProcessor.java
+++ b/TP1/src/server/handler/ClientMessageProcessor.java
@@ -12,6 +12,7 @@ import common.GameHistory;
 import java.io.BufferedReader;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.List;
 
 public class ClientMessageProcessor {
 
@@ -65,6 +66,7 @@ public class ClientMessageProcessor {
                 case "logoutRequest" -> handleLogout(payload);
                 case "getProfileRequest" -> handleGetProfile(payload);
                 case "quitMatch" -> handleQuitMatch(payload);
+                case "getRankingRequest" -> handleGetRanking();
                 case null -> System.err.println("Erro no tipo de mensagem recebida");
                 default -> System.err.println("Tipo de mensagem desconhecido: " + type);
             }
@@ -278,5 +280,12 @@ public class ClientMessageProcessor {
         MatchmakingQueue.removeFromQueue(client);
 
         ActiveGamesManager.endGameForClient(client);
+    }
+
+    private void handleGetRanking() {
+        List<PlayerRecord> players = new ArrayList<>(userDb.getAllPlayers());
+
+        String response = XmlMessageBuilder.buildRankingResponseArray(players);
+        client.send(response);
     }
 }


### PR DESCRIPTION
This pull request introduces functionality to support a new "getRankingRequest" feature, allowing clients to request and receive player rankings. The changes span multiple files and include updates to XML schema definitions, database access methods, and message handling logic.

### Feature Implementation: "getRankingRequest"

#### XML Schema Updates:
* [`TP1/src/common/xsd/gameProtocol.xsd`](diffhunk://#diff-e231cb7a19297ac27e0c535e08d3d03588f44a5666e51d66dd674e2026b238acR23-R29): Added a new `getRankingRequest` element to the schema for client requests and included `responseArray` to support the ranking response structure.
* [`TP1/src/common/xsd/response.xsd`](diffhunk://#diff-102c4276601eb9efde8a150d89c6d60e34d45775e8ce2372e1aa18d025e843a8R21-R28): Defined the `responseArray` element to encapsulate multiple `response` elements for ranking data.

#### Database Enhancements:
* [`TP1/src/server/database/UserDatabase.java`](diffhunk://#diff-dcd890ac9ab80f2a7397b7b0459f6f6e88a3c139fa5c38373e2d11e66bf6c059R118-R124): Added a `getAllPlayers` method to retrieve all registered players from the database as a collection.

#### Message Handling Logic:
* [`TP1/src/server/handler/ClientMessageProcessor.java`](diffhunk://#diff-7baaf4497e4dcba28064f4959443c310fbb64fb82cf7d213d157397a9698599bR69): Integrated the "getRankingRequest" case into the `process` method and implemented `handleGetRanking` to fetch player data, build the ranking response using `XmlMessageBuilder`, and send it to the client. [[1]](diffhunk://#diff-7baaf4497e4dcba28064f4959443c310fbb64fb82cf7d213d157397a9698599bR69) [[2]](diffhunk://#diff-7baaf4497e4dcba28064f4959443c310fbb64fb82cf7d213d157397a9698599bR284-R290)

#### XML Message Builder:
* [`TP1/src/common/XmlMessageBuilder.java`](diffhunk://#diff-28184c56d789db433550a7cdf238ea6b2fa94c725d66c320245d22d4cd296fe8R141-R160): Added the `buildRankingResponseArray` method to construct XML responses containing player ranking data.